### PR TITLE
adding an empty line before @export and rounding values for month con…

### DIFF
--- a/R/splineInterpolateMonthlytoDaily.R
+++ b/R/splineInterpolateMonthlytoDaily.R
@@ -11,6 +11,7 @@ NULL
 #' @param last_row corresponding the last day of time interval where montlhy mean conservation is applied
 #' @param no_spline logical value. If \code{TRUE} no spline interpolation is calculated and the daily value corresponds to the monthly average value. Default is \code{FALSE}.
 #' @param no_mean logical value. Default is \code{FALSE}. If \code{TRUE} the function output is not rescaled in order to maintain observed mean monthly values.
+#'
 #' @export
 #'
 #' @return a matrix or data frame with interpolated daily data
@@ -50,7 +51,7 @@ function(nday=365,val=as.matrix(cbind(1*(0.5:11.5)*nday/12,2*(0.5:11.5)*nday/12)
 		out1 <- as.vector(out$y) # insert monthds correctly!!!
 		out2 <- out1
 
-		months <- months_f((0.5:11.5)*365/12,abbreviate=TRUE)
+		months <- months_f(round((0.5:11.5))*365/12,abbreviate=TRUE)
 
 		for (m in 1:length(months)) {
 


### PR DESCRIPTION
…version
Hi Emanuele and Emanuele,
I tried using the new package version today, and it generated an error that I was able to trace to the new version of the splineInterpolateMonthlytoDaily function. It seems you missed an empty line before the export command (the "export" shows up in the documentation now, and the function isn't findable). More importantly, the months_f conversion appears to only work with integers - this generated an error for me. I suggest adding a "round".
With this addition, it seems the function works well again.
All the best,
Eike
